### PR TITLE
Default guids

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,7 @@ class Provider < ApplicationRecord
   include EmsRefresh::Manager
   include SupportsFeatureMixin
   include TenancyMixin
+  include UuidMixin
 
   belongs_to :tenant
   belongs_to :zone

--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -1,22 +1,17 @@
 module UuidMixin
   extend ActiveSupport::Concern
   included do
-    before_validation :set_guid, :on => :create if respond_to?(:before_validation)
+    default_value_for(:guid, :allows_nil => false) { SecureRandom.uuid }
     validates :guid,  :uniqueness => true, :presence => true
   end
 
   def dup
-    super.tap { |obj| obj.guid = nil }
+    super.tap { |obj| obj.guid = SecureRandom.uuid }
   end
 
   private
 
-  def set_guid
-    self.guid ||= SecureRandom.uuid if self.respond_to?(:guid) && self.respond_to?(:guid=)
-  end
-
   def default_name_to_guid
-    set_guid
     self.name ||= self.guid if self.respond_to?(:guid) && self.respond_to?(:name) && self.respond_to?(:name=)
   end
 end

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :chargeback_rate do
-    guid                   { SecureRandom.uuid }
     sequence(:description) { |n| "Chargeback Rate ##{n}" }
     rate_type { 'Compute' }
 

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     sequence(:name)      { |n| "ems_#{seq_padded_for_sorting(n)}" }
     sequence(:hostname)  { |n| "ems-#{seq_padded_for_sorting(n)}" }
     sequence(:ipaddress) { |n| ip_from_seq(n) }
-    guid                 { SecureRandom.uuid }
     zone                 { FactoryBot.create(:zone) }
     storage_profiles     { [] }
 

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :miq_server do
-    guid            { SecureRandom.uuid }
     zone            { FactoryBot.build(:zone) }
     sequence(:name) { |n| "miq_server_#{seq_padded_for_sorting(n)}" }
     last_heartbeat  { Time.now.utc }

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :provider do
     sequence(:name) { |n| "provider_#{seq_padded_for_sorting(n)}" }
-    guid            { SecureRandom.uuid }
     zone            { FactoryBot.create(:zone) }
   end
 

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -292,7 +292,7 @@ describe CustomButton do
 
       it "returns the button as a serializable hash with the resource action serialized hash" do
         expect(test_button.expanded_serializable_hash).to eq(
-          expected_hash.merge(:resource_action => "resource_action_hash")
+          expected_hash.merge("guid" => test_button.guid, :resource_action => "resource_action_hash")
         )
       end
     end
@@ -301,7 +301,7 @@ describe CustomButton do
       let(:resource_action) { nil }
 
       it "returns the button as a serializable hash" do
-        expect(test_button.expanded_serializable_hash).to eq(expected_hash)
+        expect(test_button.expanded_serializable_hash).to eq(expected_hash.merge("guid" => test_button.guid))
       end
     end
   end


### PR DESCRIPTION
- Switch to using `default_value_for`
- Remove setting `guid` in factories where the model includes this mixin
- Add `UuidMixin` to `Provider`